### PR TITLE
Implement alternate console presentation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ async function main() {
       } else {
         process.stderr.write(C_ERR_TEXT(`${e.message ?? "unable to process requests"}\n`));
       }
-      process.exitCode = (process.exitCode ?? 0) + 1;
+      process.exitCode = Number(process.exitCode ?? 0) + 1;
       continue;
     }
   }

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -3,9 +3,12 @@ import chalkStderr from "chalk";
 export const C_PATH = chalkStderr.cyan; // path
 
 export const C_LOADING = chalkStderr.blue.italic; // loading
-export const C_TIME = chalkStderr.magenta.italic.underline; // time
+export const C_TIME = chalkStderr.gray; // time
 
-export const C_SPEC = chalkStderr.white.bold.italic; // spec
+export const C_SPEC = chalkStderr.white; // spec
+
+export const C_STATUS = chalkStderr.cyanBright;
+export const C_OP = chalkStderr.cyanBright.italic;
 
 // error
 export const C_ERR = chalkStderr.red.bold;
@@ -19,7 +22,11 @@ export const C_SUC_TEXT = chalkStderr.green;
 // warning
 export const C_WARN = chalkStderr.yellow.bold;
 export const C_WARN_TEXT = chalkStderr.yellow;
+export const C_WARN_TOKENS = chalkStderr.magenta;
 
 // skip
 export const C_SKIP = chalkStderr.gray.bold;
-export const C_SKIP_TEXT = chalkStderr.gray;
+
+// normal text
+export const C_TEXT_BOLD = chalkStderr.whiteBright.bold;
+export const C_TEXT = chalkStderr.gray;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,3 @@
-import { C_ERR_TEXT } from "./colours";
-
 export function getStatusCode() {
-  return process.exitCode ?? 0;
+  return Number(process.exitCode ?? 0);
 }


### PR DESCRIPTION
I'd like to propose an alternative to the current log-inspired console output.

Here is a comparison of `zzapi/examples/tests-bundle.zzb` with the current console output and this PR's alternative.

| Current | Proposal |
|--------|--------|
| <img width="1268" alt="image" src="https://github.com/agrostar/zzapi-cli/assets/868217/63ad64f2-537c-4c02-8281-ae18909d400d"> |  <img width="1096" alt="image" src="https://github.com/agrostar/zzapi-cli/assets/868217/01aaddb9-0cc9-42e6-88c4-80dbe229078c"> |

The objectives of this PR are to:
- introduce the concept of bundle name, currently taken from the filename
- use color to draw attention to the right pieces of information on a given line of console output

