### PR TITLE
Supporting multiple bundles in zzapi-cli

### DIFF
--- a/.github/workflows/test bundles/check_failing_reqs.sh
+++ b/.github/workflows/test bundles/check_failing_reqs.sh
@@ -1,3 +1,5 @@
+# ensure that the expected requests are failing
+
 node ./dist/index.js ./.github/workflows/test\ bundles/tests-bundle.zzb --env default --req tests-negative-response;
 exitCode=$?
 if [ $exitCode -ne 1 ]; then
@@ -12,4 +14,3 @@ if [ $exitCode -ne 1 ]; then
     exit $exitCode; 
 fi
 
-# ensure that the expected requests are failing

--- a/.github/workflows/test bundles/multiple_bundles.sh
+++ b/.github/workflows/test bundles/multiple_bundles.sh
@@ -1,0 +1,7 @@
+# ensure that multiple bundles can be run 
+node ./dist/index.js ./.github/workflows/test\ bundles/tests-bundle.zzb ./.github/workflows/test\ bundles/second-bundle.zzb --env default
+exitCode=$?
+if [ $exitCode -ne 2 ]; then
+    echo "exit code is $exitCode, expected 2";
+    exit $exitCode; 
+fi

--- a/.github/workflows/test bundles/second-bundle.zzb
+++ b/.github/workflows/test bundles/second-bundle.zzb
@@ -1,0 +1,29 @@
+common:
+  baseUrl: https://postman-echo.com
+  headers:
+    Content-type: application/json
+  tests:
+    status: 200
+    $h.Content-type: application/json; charset=utf-8
+
+
+requests:
+  simple-get: { method: GET, url: /get }
+
+  get-with-params:
+    method: GET
+    url: /get
+    params:
+      foo: bar
+    tests: # old way of specifying json tests
+      json:
+        $.args.foo: bar
+
+  get-with-params-no-value:
+    method: GET
+    url: /get
+    params:
+      foo1: bar1
+      foo2:
+    tests: # new way of specifying json
+      $.url: "https://postman-echo.com/get?foo1=bar1&foo2"

--- a/.github/workflows/test bundles/test_bundle.sh
+++ b/.github/workflows/test bundles/test_bundle.sh
@@ -1,3 +1,4 @@
+# ensure that exactly 2 requests are failing, and the rest work as expected
 node ./dist/index.js ./.github/workflows/test\ bundles/tests-bundle.zzb --env default;
 exitCode=$?
 if [ $exitCode -ne 2 ]; then
@@ -5,4 +6,3 @@ if [ $exitCode -ne 2 ]; then
     exit $exitCode; 
 fi
 
-# ensure that exactly 2 requests are failing, and the rest work as expected

--- a/.github/workflows/test_bundle.yml
+++ b/.github/workflows/test_bundle.yml
@@ -20,3 +20,6 @@ jobs:
       - name: assert failing requests
         run: |
           bash ./.github/workflows/test\ bundles/check_failing_reqs.sh
+      - name: checking for multiple bundles in a single command
+        run: |
+          bash ./.github/workflows/test\ bundles/multiple_bundles.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "zzapi-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zzapi-cli",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "commander": "^11.1.0",
-        "zzapi": "^1.2.0"
+        "zzapi": "^1.2.1"
       },
       "bin": {
         "zzapi-cli": "dist/index.js"
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/zzapi": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zzapi/-/zzapi-1.2.0.tgz",
-      "integrity": "sha512-TpkS/8ElgLZi7U+7QAl8Fdn/Jn3hcgKhVCp6lLXWWDObS3Clwe92WDqHPrXpMOPYeB4LrBjfUFOtleu9GNJiOw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/zzapi/-/zzapi-1.2.1.tgz",
+      "integrity": "sha512-WfH7wcxQK4HgrIYrAqpW3QAgP/1pFJeyboboBgVYCI5iGNqFBuBMMplZUsoZqQSqf6KiMnejGMe+FsEA6sCYXQ==",
       "dependencies": {
         "got": "11.8.6",
         "jsonpath": "^1.1.1",

--- a/src/fileContents.ts
+++ b/src/fileContents.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 
 import { getRawRequest } from "./utils/requestUtils";
 
-export function replaceFileContents<T>(body: T): T {
+export function replaceFileContents<T>(body: T, bundlePath: string): T {
   if (typeof body !== "string") return body;
 
   /*
@@ -14,7 +14,7 @@ export function replaceFileContents<T>(body: T): T {
   return body.replace(fileRegex, (match, givenFilePath) => {
     if (match !== body) return match; // we only perform a replacement if file:// is the ENTIRE body
 
-    const filePath = path.resolve(path.dirname(getRawRequest().bundle.bundlePath), givenFilePath);
+    const filePath = path.resolve(path.dirname(bundlePath), givenFilePath);
     return fs.readFileSync(filePath, "utf-8");
   }) as T & string;
 }

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -38,9 +38,12 @@ function formatTestResults(results: TestResult[]): string {
   return resultLines.join("\n");
 }
 
-export async function allRequestsWithProgress(allRequests: {
-  [name: string]: RequestSpec;
-}): Promise<Array<{ name: string; response: ResponseData }>> {
+export async function allRequestsWithProgress(
+  allRequests: {
+    [name: string]: RequestSpec;
+  },
+  bundlePath: string
+): Promise<Array<{ name: string; response: ResponseData }>> {
   let currHttpRequest: GotRequest;
   let responses: Array<{ name: string; response: ResponseData }> = [];
 
@@ -48,7 +51,7 @@ export async function allRequestsWithProgress(allRequests: {
     let requestData = allRequests[name];
     const method = requestData.httpRequest.method;
 
-    requestData.httpRequest.body = replaceFileContents(requestData.httpRequest.body);
+    requestData.httpRequest.body = replaceFileContents(requestData.httpRequest.body, bundlePath);
     const undefs = replaceVariablesInRequest(requestData, getVarStore().getAllVariables());
     currHttpRequest = constructGotRequest(requestData);
 
@@ -121,7 +124,7 @@ export async function allRequestsWithProgress(allRequests: {
         C_TIME(`${new Date().toLocaleString()}`) +
         C_ERR(` [ERROR] `) +
         C_ERR_TEXT(
-          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`,
+          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`
         );
       process.stderr.write(`\r${message}\n`);
       process.exitCode = getStatusCode() + 1;

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -42,7 +42,7 @@ export async function allRequestsWithProgress(
   allRequests: {
     [name: string]: RequestSpec;
   },
-  bundlePath: string
+  bundlePath: string,
 ): Promise<Array<{ name: string; response: ResponseData }>> {
   let currHttpRequest: GotRequest;
   let responses: Array<{ name: string; response: ResponseData }> = [];
@@ -124,7 +124,7 @@ export async function allRequestsWithProgress(
         C_TIME(`${new Date().toLocaleString()}`) +
         C_ERR(` [ERROR] `) +
         C_ERR_TEXT(
-          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`
+          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`,
         );
       process.stderr.write(`\r${message}\n`);
       process.exitCode = getStatusCode() + 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,21 +5,20 @@ import { Command } from "commander";
 import { getRawRequest } from "./utils/requestUtils";
 import { CLI_NAME, CLI_VERSION } from "./utils/version";
 import { getStatusCode } from "./utils/errors";
-import { C_ERR_TEXT, C_WARN_TEXT } from "./utils/colours";
+import { C_ERR_TEXT, C_PATH, C_WARN_TEXT } from "./utils/colours";
 
 import { callRequests } from "./runRequests";
 
 const program = new Command(CLI_NAME);
 program
   .showHelpAfterError(C_WARN_TEXT(`(enter ${CLI_NAME} -h for usage information)`))
-  .allowExcessArguments(true)
   .configureOutput({
     writeErr: (str) => process.stderr.write(str),
     outputError: (str, write) => write(C_ERR_TEXT(str)),
   })
   .version(CLI_VERSION, "-v, --version", "show the current version")
   .description("CLI for zzAPI - an API testing framework")
-  .argument("<path-to-bundle>", "The bundle whose requests to run")
+  .arguments("<path-to-bundles>")
   .option("-r, --req <req-name>", "Run a request of a particular name")
   .option("-e, --env <env-name>", "Run the request in a particular environment")
   .option("--expand", "Show the body output in the terminal")
@@ -27,14 +26,24 @@ program
 
 async function main() {
   const options = program.opts();
+  options.expand = options.expand === true;
 
-  // create the raw request
-  const pathArg = program.args[0];
-  const rawReq = getRawRequest(pathArg, options.expand === true, options.req, options.env);
-  if (getStatusCode() > 0) return;
-
-  // finally, call the request
-  await callRequests([rawReq]);
+  const bundlePaths = program.args;
+  for (const bundlePath of bundlePaths) {
+    process.stderr.write(C_PATH(`\nRunning bundle: ${bundlePath}\n`));
+    try {
+      const rawReq = getRawRequest(bundlePath, options.expand, options.req, options.env);
+      await callRequests(rawReq);
+    } catch (e: any) {
+      if (typeof e === "string") {
+        process.stderr.write(C_ERR_TEXT(`${e}\n`));
+      } else {
+        process.stderr.write(C_ERR_TEXT(`${e.message ?? "unable to process requests"}\n`));
+      }
+      process.exitCode = (process.exitCode ?? 0) + 1;
+      continue;
+    }
+  }
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { Command } from "commander";
 
-import { initRawRequest } from "./utils/requestUtils";
+import { getRawRequest } from "./utils/requestUtils";
 import { CLI_NAME, CLI_VERSION } from "./utils/version";
 import { getStatusCode } from "./utils/errors";
 import { C_ERR_TEXT, C_WARN_TEXT } from "./utils/colours";
@@ -12,7 +12,7 @@ import { callRequests } from "./runRequests";
 const program = new Command(CLI_NAME);
 program
   .showHelpAfterError(C_WARN_TEXT(`(enter ${CLI_NAME} -h for usage information)`))
-  .allowExcessArguments(false)
+  .allowExcessArguments(true)
   .configureOutput({
     writeErr: (str) => process.stderr.write(str),
     outputError: (str, write) => write(C_ERR_TEXT(str)),
@@ -30,11 +30,11 @@ async function main() {
 
   // create the raw request
   const pathArg = program.args[0];
-  initRawRequest(pathArg, options.expand === true, options.req, options.env);
+  const rawReq = getRawRequest(pathArg, options.expand === true, options.req, options.env);
   if (getStatusCode() > 0) return;
 
   // finally, call the request
-  await callRequests();
+  await callRequests([rawReq]);
 }
 
 main();

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -4,7 +4,7 @@ import { RequestSpec, Variables } from "zzapi";
 import { getAllRequestSpecs, getRequestSpec } from "zzapi";
 import { loadVariables } from "zzapi";
 
-import { getRawRequest } from "./utils/requestUtils";
+import { RawRequest } from "./utils/requestUtils";
 import { throwError } from "./utils/errors";
 import { C_WARN } from "./utils/colours";
 import { CLI_VERSION } from "./utils/version";
@@ -13,7 +13,10 @@ import { showContentForIndReq, showContentForAllReq } from "./showRes";
 import { allRequestsWithProgress } from "./getResponse";
 import { getVarFileContents, getVarStore } from "./variables";
 
-async function runRequestSpecs(requests: { [name: string]: RequestSpec }): Promise<void> {
+async function runRequestSpecs(
+  requests: { [name: string]: RequestSpec },
+  rawRequest: RawRequest
+): Promise<void> {
   for (const name in requests) {
     const request = requests[name];
 
@@ -24,48 +27,62 @@ async function runRequestSpecs(requests: { [name: string]: RequestSpec }): Promi
     request.httpRequest.headers = Object.assign(autoHeaders, request.httpRequest.headers);
   }
 
-  const responses = await allRequestsWithProgress(requests);
-
+  const responses = await allRequestsWithProgress(requests, rawRequest.bundle.bundlePath);
   if (responses.length < 1) return;
+
   // if requestName is not set, then it is meant to be a run-all requests, else run-one
-  if (!getRawRequest().requestName) {
-    await showContentForAllReq(responses);
+  if (!rawRequest.requestName) {
+    await showContentForAllReq(responses, rawRequest.envName, rawRequest.expand);
   } else {
     const name = responses[0].name;
     const req = requests[name];
     const resp = responses[0].response;
-    await showContentForIndReq(resp, name, req.options.keepRawJSON, req.options.showHeaders);
+    await showContentForIndReq(
+      resp,
+      name,
+      req.options.keepRawJSON,
+      req.options.showHeaders,
+      rawRequest.envName,
+      rawRequest.expand
+    );
   }
 }
 
-export async function callRequests(): Promise<void> {
-  // load the variables
-  try {
-    const env = getRawRequest().envName;
-    const loadedVariables: Variables = loadVariables(
-      env,
-      getRawRequest().bundle.bundleContents,
-      getVarFileContents(path.dirname(getRawRequest().bundle.bundlePath)),
-    );
-    if (env && Object.keys(loadedVariables).length < 1)
-      console.error(C_WARN(`warning: no variables added from env "${env}". Does it exist?`));
-    getVarStore().setLoadedVariables(loadedVariables);
-  } catch (err: any) {
-    throwError(err);
-    return;
+export async function callRequests(requests: RawRequest[]): Promise<void> {
+  async function runRequest(request: RawRequest) {
+    try {
+      // load the variables
+      const env = request.envName;
+      const loadedVariables: Variables = loadVariables(
+        env,
+        request.bundle.bundleContents,
+        getVarFileContents(path.dirname(request.bundle.bundlePath))
+      );
+      if (env && Object.keys(loadedVariables).length < 1)
+        console.error(C_WARN(`warning: no variables added from env "${env}". Does it exist?`));
+      getVarStore().setLoadedVariables(loadedVariables);
+    } catch (err: any) {
+      throwError(err);
+      return;
+    }
+
+    // create the request specs
+    const name = request.requestName,
+      content = request.bundle.bundleContents;
+
+    let allRequests: { [name: string]: RequestSpec };
+    try {
+      allRequests = name ? { [name]: getRequestSpec(content, name) } : getAllRequestSpecs(content);
+    } catch (err: any) {
+      throwError(err);
+      return;
+    }
+
+    // finally, run the request specs
+    await runRequestSpecs(allRequests, request);
   }
 
-  // run the requests
-  const name = getRawRequest().requestName,
-    content = getRawRequest().bundle.bundleContents;
-
-  let allRequests: { [name: string]: RequestSpec };
-  try {
-    allRequests = name ? { [name]: getRequestSpec(content, name) } : getAllRequestSpecs(content);
-  } catch (err: any) {
-    throwError(err);
-    return;
-  }
-
-  await runRequestSpecs(allRequests);
+  requests.forEach(async (request) => {
+    runRequest(request);
+  });
 }

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -14,7 +14,7 @@ import { getVarFileContents, getVarStore } from "./variables";
 
 async function runRequestSpecs(
   requests: { [name: string]: RequestSpec },
-  rawRequest: RawRequest
+  rawRequest: RawRequest,
 ): Promise<void> {
   for (const name in requests) {
     const request = requests[name];
@@ -42,7 +42,7 @@ async function runRequestSpecs(
       req.options.keepRawJSON,
       req.options.showHeaders,
       rawRequest.envName,
-      rawRequest.expand
+      rawRequest.expand,
     );
   }
 }
@@ -54,7 +54,7 @@ export async function callRequests(request: RawRequest): Promise<void> {
     const loadedVariables: Variables = loadVariables(
       env,
       request.bundle.bundleContents,
-      getVarFileContents(path.dirname(request.bundle.bundlePath))
+      getVarFileContents(path.dirname(request.bundle.bundlePath)),
     );
     if (env && Object.keys(loadedVariables).length < 1)
       console.error(C_WARN(`warning: no variables added from env "${env}". Does it exist?`));

--- a/src/showRes.ts
+++ b/src/showRes.ts
@@ -10,9 +10,11 @@ export async function showContentForIndReq(
   name: string,
   keepRawJSON: boolean,
   showHeaders: boolean,
+  env: string | undefined,
+  expand: boolean
 ): Promise<void> {
-  const { contentData, headersData } = getDataOfIndReqAsString(responseData, name, keepRawJSON);
-  showContent(contentData, headersData, showHeaders, name);
+  const { contentData, headersData } = getDataOfIndReqAsString(responseData, name, env, keepRawJSON);
+  showContent(contentData, headersData, showHeaders, expand, name);
 }
 
 function attemptDataParse(content: string): object | undefined {
@@ -27,7 +29,9 @@ function attemptDataParse(content: string): object | undefined {
 
 export async function showContentForAllReq(
   responses: Array<{ response: ResponseData; name: string }>,
-  keepRawJSON?: boolean,
+  env: string | undefined,
+  expand: boolean,
+  keepRawJSON?: boolean
 ): Promise<void> {
   let allResponses: { [key: string]: any } = {};
 
@@ -35,22 +39,24 @@ export async function showContentForAllReq(
     let contentData = getDataOfIndReqAsString(
       responseObj.response,
       responseObj.name,
-      keepRawJSON,
+      env,
+      keepRawJSON
     ).contentData;
 
     let parsedData = attemptDataParse(contentData);
     allResponses[responseObj.name] = parsedData ? parsedData : contentData;
   });
 
-  showContent(JSON.stringify(allResponses, undefined, 2), "", false);
+  showContent(JSON.stringify(allResponses, undefined, 2), "", false, expand);
 }
 
 function getDataOfIndReqAsString(
   responseData: ResponseData,
   name: string,
-  keepRawJSON?: boolean,
+  env: string | undefined,
+  keepRawJSON?: boolean
 ): { contentData: string; headersData: string } {
-  let currentEnvironment: string = (getRawRequest().envName ? getRawRequest().envName : "") as string;
+  let currentEnvironment: string = env ?? "";
 
   let contentData = "";
   let headersData = `${name}: headers\nenvironment: ${currentEnvironment}\n\n`;
@@ -81,9 +87,15 @@ function getDataOfIndReqAsString(
  *  response. Thus, any name === undefined test is to determine this.
  * @returns (void)
  */
-function showContent(bodyContent: string, headersContent: string, showHeaders: boolean, name?: string) {
+function showContent(
+  bodyContent: string,
+  headersContent: string,
+  showHeaders: boolean,
+  expand: boolean,
+  name?: string
+) {
   // showing the body
-  if (getRawRequest().expand) console.log(bodyContent);
+  if (expand) console.log(bodyContent);
   // showing the headers
   if (name && showHeaders) console.error("----------\n" + headersContent + "\n----------\n");
 }

--- a/src/showRes.ts
+++ b/src/showRes.ts
@@ -11,7 +11,7 @@ export async function showContentForIndReq(
   keepRawJSON: boolean,
   showHeaders: boolean,
   env: string | undefined,
-  expand: boolean
+  expand: boolean,
 ): Promise<void> {
   const { contentData, headersData } = getDataOfIndReqAsString(responseData, name, env, keepRawJSON);
   showContent(contentData, headersData, showHeaders, expand, name);
@@ -31,7 +31,7 @@ export async function showContentForAllReq(
   responses: Array<{ response: ResponseData; name: string }>,
   env: string | undefined,
   expand: boolean,
-  keepRawJSON?: boolean
+  keepRawJSON?: boolean,
 ): Promise<void> {
   let allResponses: { [key: string]: any } = {};
 
@@ -40,7 +40,7 @@ export async function showContentForAllReq(
       responseObj.response,
       responseObj.name,
       env,
-      keepRawJSON
+      keepRawJSON,
     ).contentData;
 
     let parsedData = attemptDataParse(contentData);
@@ -54,7 +54,7 @@ function getDataOfIndReqAsString(
   responseData: ResponseData,
   name: string,
   env: string | undefined,
-  keepRawJSON?: boolean
+  keepRawJSON?: boolean,
 ): { contentData: string; headersData: string } {
   let currentEnvironment: string = env ?? "";
 
@@ -92,7 +92,7 @@ function showContent(
   headersContent: string,
   showHeaders: boolean,
   expand: boolean,
-  name?: string
+  name?: string,
 ) {
   // showing the body
   if (expand) console.log(bodyContent);

--- a/src/utils/bundleUtils.ts
+++ b/src/utils/bundleUtils.ts
@@ -1,8 +1,6 @@
 import path from "path";
 import * as fs from "fs";
 
-import { getStatusCode, throwError } from "./errors";
-
 const BUNDLE_FILE_NAME_ENDINGS = [".zzb", ".zzb.yml", ".zzb.yaml"] as const;
 
 export class Bundle {
@@ -10,25 +8,21 @@ export class Bundle {
   public bundleContents: string = "";
 
   constructor(relPath: string) {
-    this.setBundlePath(relPath);
-    if (getStatusCode() > 0) return;
-    this.readContents();
+    try {
+      this.setBundlePath(relPath);
+      this.readContents();
+    } catch (e) {
+      throw e;
+    }
   }
 
   setBundlePath(relPath: string) {
-    if (!BUNDLE_FILE_NAME_ENDINGS.some((ending) => relPath.endsWith(ending))) {
-      throwError(`error: ${relPath} is not a valid bundle`);
-      return;
-    }
+    if (!BUNDLE_FILE_NAME_ENDINGS.some((ending) => relPath.endsWith(ending)))
+      throw `error: ${relPath} is not a valid bundle`;
+
     this.bundlePath = path.resolve(relPath);
-    if (!fs.existsSync(this.bundlePath)) {
-      throwError(`error: ${this.bundlePath} does not exist`);
-      return;
-    }
-    if (!fs.lstatSync(this.bundlePath).isFile()) {
-      throwError(`error: ${this.bundlePath} is not a file`);
-      return;
-    }
+    if (!fs.existsSync(this.bundlePath)) throw `error: ${this.bundlePath} does not exist`;
+    if (!fs.lstatSync(this.bundlePath).isFile()) throw `error: ${this.bundlePath} is not a file`;
   }
 
   readContents() {

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -1,5 +1,7 @@
 import chalkStderr from "chalk";
 
+export const C_PATH = chalkStderr.cyan; // path
+
 export const C_LOADING = chalkStderr.blue.italic; // loading
 export const C_TIME = chalkStderr.magenta.italic.underline; // time
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -3,8 +3,3 @@ import { C_ERR_TEXT } from "./colours";
 export function getStatusCode() {
   return process.exitCode ?? 0;
 }
-
-export function throwError(message: any): void {
-  console.error(C_ERR_TEXT(message));
-  process.exitCode = 1;
-}

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -1,6 +1,6 @@
 import { Bundle } from "./bundleUtils";
 
-class RawRequest {
+export class RawRequest {
   public requestName: string | undefined = undefined;
   public envName: string | undefined = undefined;
   public expand: boolean = false;
@@ -14,15 +14,11 @@ class RawRequest {
   }
 }
 
-let req: RawRequest;
-export function initRawRequest(
+export function getRawRequest(
   relPath: string,
   expand: boolean,
   requestName?: string,
-  envName?: string,
-) {
-  req = new RawRequest(relPath, expand, requestName, envName);
-}
-export function getRawRequest(): RawRequest {
-  return req;
+  envName?: string
+): RawRequest {
+  return new RawRequest(relPath, expand, requestName, envName);
 }

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -22,7 +22,7 @@ export function getRawRequest(
   relPath: string,
   expand: boolean,
   requestName?: string,
-  envName?: string
+  envName?: string,
 ): RawRequest {
   try {
     return new RawRequest(relPath, expand, requestName, envName);

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -7,10 +7,14 @@ export class RawRequest {
   public bundle: Bundle;
 
   constructor(relPath: string, expand: boolean, requestName?: string, envName?: string) {
-    this.bundle = new Bundle(relPath);
-    this.requestName = requestName;
-    this.envName = envName;
-    this.expand = expand;
+    try {
+      this.bundle = new Bundle(relPath);
+      this.requestName = requestName;
+      this.envName = envName;
+      this.expand = expand;
+    } catch (e) {
+      throw e;
+    }
   }
 }
 
@@ -20,5 +24,9 @@ export function getRawRequest(
   requestName?: string,
   envName?: string
 ): RawRequest {
-  return new RawRequest(relPath, expand, requestName, envName);
+  try {
+    return new RawRequest(relPath, expand, requestName, envName);
+  } catch (error) {
+    throw error;
+  }
 }


### PR DESCRIPTION
Fixing issue [#12 in zzapi-vscode](https://github.com/agrostar/zzapi-vscode/issues/12). 

Supports multiple explicit bundle paths as arguments in a single zzapi-cli command. 