### PR TITLE
printing output with varying indentation for recursive $tests clauses

### DIFF
--- a/.github/workflows/test bundles/tests-bundle.zzb
+++ b/.github/workflows/test bundles/tests-bundle.zzb
@@ -265,16 +265,19 @@ requests:
       status: { $ne: 200 }
       $h.content-type: { $exists: false }
       # regular things that should fail
-      $.data.name: { $type: array }
-      $.data.missing: { $size: 0, $exists: true } # should report 2 failures
-      $.data.missing.missing.missing: { $exists: true }
-      $.data.numbers.0: "444" # 444 is not same as "444". We use === for $eq and !== for $neq
-
-      # stress: ensure corner cases don't crash
-      $.data.age: { $size: 2 } # .length not supported for type: number
-      $.data.numbers[?(.@)]: 4 # invalid path
-      $.data.age.something: 55 # jsonpath should take care of this.
-      $.data.numbers[5]: 0 # jsonpath should take care of this
+      $.data:
+        $tests:
+          $.name: {$type: array}
+          $.missing: 
+            $size: 0
+            $exists: true 
+            $tests: 
+              $.missing.missing: { $exists: true }
+          $.numbers.0: "444" # 444 is not same as "444". We use === for $eq and !== for $neq
+          $.age: { $size: 2 } # .length not supported for type: number
+          $.numbers[?(.@)]: 4 # invalid path
+          $.age.something: 55 # jsonpath should take care of this.
+          $.numbers[5]: 0 # jsonpath should take care of this
 
   # This request tests should all fail due to bad tests schema
   # Ensure we don't crash on these.

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -7,6 +7,7 @@ import { replaceVariablesInRequest } from "zzapi";
 import { getVarStore } from "./variables";
 import {
   C_ERR,
+  C_ERR_INFO,
   C_ERR_TEXT,
   C_LOADING,
   C_SUC,
@@ -14,6 +15,7 @@ import {
   C_TIME,
   C_WARN,
   C_WARN_TEXT,
+  C_SPEC,
 } from "./utils/colours";
 import { getStatusCode } from "./utils/errors";
 import { replaceFileContents } from "./fileContents";
@@ -27,7 +29,7 @@ function formatTestResults(results: TestResult[]): string[] {
     } else {
       line = C_ERR(`[FAIL]`) + C_ERR_TEXT(` test expected ${r.op}: ${r.expected} | got ${r.received}`);
     }
-    if (r.message) line = `${line} [${r.message}]`;
+    if (r.message) line += C_ERR_INFO(`[${r.message}]`);
 
     resultLines.push(line);
   }
@@ -69,10 +71,10 @@ function getFormattedResult(
   function getIndentedResult(res: SpecResult, indent: number = 1): string {
     if (passed === all) return "";
 
+    const specName = C_SPEC(res.spec ? "\t".repeat(indent - 1) + res.spec : "");
     const testResults = formatTestResults(res.results)
       .map((r) => "\t".repeat(indent) + r)
       .join("\n");
-    const specName = res.spec ? "\t".repeat(indent - 1) + res.spec : "";
 
     const subRes: string[] = [];
     for (const s of res.subResults) subRes.push(getIndentedResult(s, indent + 1));

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -42,7 +42,7 @@ function getFormattedResult(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): [string, number, number] {
   function getResultData(res: SpecResult): [number, number] {
     const rootResults = res.results;
@@ -181,7 +181,7 @@ export async function allRequestsWithProgress(allRequests: {
         C_TIME(`${new Date().toLocaleString()}`) +
         C_ERR(` [ERROR] `) +
         C_ERR_TEXT(
-          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`
+          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`,
         );
       process.stderr.write(`${message}\n`);
       process.exitCode = getStatusCode() + 1;

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -3,9 +3,12 @@ import chalkStderr from "chalk";
 export const C_LOADING = chalkStderr.blue.italic; // loading
 export const C_TIME = chalkStderr.magenta.italic.underline; // time
 
+export const C_SPEC = chalkStderr.white.bold.italic; // spec
+
 // error
 export const C_ERR = chalkStderr.red.bold;
 export const C_ERR_TEXT = chalkStderr.red;
+export const C_ERR_INFO = chalkStderr.red.bold.italic;
 
 // success
 export const C_SUC = chalkStderr.green.bold;


### PR DESCRIPTION
> This depends on the SpecResult type introduced in [#7 of the zzapi repo](https://github.com/agrostar/zzapi/pull/7). 

- [X] Prints the test results in a recursive format with varying indentation, to show the utility of the SpecResult type. 
![Screenshot from 2024-06-03 01-15-10](https://github.com/agrostar/zzapi-cli/assets/125901917/c9d87bec-df70-4be6-9612-271cf8be6de9)

- [ ] This styling is temporary, and expected to be over-ridden soon.