### PR TITLE
add option for indented output, defaulting to flat output

### DIFF
--- a/src/fileContents.ts
+++ b/src/fileContents.ts
@@ -1,8 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { getRawRequest } from "./utils/requestUtils";
-
 export function replaceFileContents<T>(body: T, bundlePath: string): T {
   if (typeof body !== "string") return body;
 

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -61,10 +61,6 @@ function getStatusString(
   size: number,
   execTime: string | number,
 ): string {
-  let message: string =
-    C_TIME(`${new Date().toLocaleString()}`) +
-    (all === passed ? C_SUC(` [INFO]  `) : C_ERR(` [ERROR] `));
-
   const passRatio = all === 0 ? "" : `tests: ${passed}/${all} passed`;
   const summaryString = `${method} ${name} status: ${status} size: ${size} B time: ${execTime} ${passRatio}`;
 

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -59,7 +59,7 @@ function getStatusString(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): string {
   let message: string =
     C_TIME(`${new Date().toLocaleString()}`) +
@@ -80,7 +80,7 @@ function getFlatResult(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): [string, number, number] {
   const [passed, all] = getPassData(specRes);
   if (passed === all)
@@ -113,7 +113,7 @@ function getIndentedResult(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): [string, number, number] {
   const [passed, all] = getPassData(specRes);
   if (passed === all)
@@ -150,7 +150,7 @@ function getRequestResult(
   status: number | undefined,
   size: number,
   execTime: string | number,
-  indent: boolean
+  indent: boolean,
 ): [string, number, number] {
   return indent
     ? getIndentedResult(specRes, method, name, status, size, execTime)
@@ -162,7 +162,7 @@ export async function allRequestsWithProgress(
     [name: string]: RequestSpec;
   },
   bundlePath: string,
-  indent: boolean
+  indent: boolean,
 ): Promise<Array<{ name: string; response: ResponseData }>> {
   let currHttpRequest: GotRequest;
   let responses: Array<{ name: string; response: ResponseData }> = [];
@@ -245,7 +245,7 @@ export async function allRequestsWithProgress(
         C_TIME(`${new Date().toLocaleString()}`) +
         C_ERR(` [ERROR] `) +
         C_ERR_TEXT(
-          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`
+          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`,
         );
       process.stderr.write(`${message}\n`);
       process.exitCode = getStatusCode() + 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,11 @@
 
 import { Command } from "commander";
 
-import { getRawRequest } from "./utils/requestUtils";
 import { CLI_NAME, CLI_VERSION } from "./utils/version";
-import { getStatusCode } from "./utils/errors";
 import { C_ERR_TEXT, C_PATH, C_WARN_TEXT } from "./utils/colours";
 
 import { callRequests } from "./runRequests";
+import { RawRequest } from "./utils/requestUtils";
 
 const program = new Command(CLI_NAME);
 program
@@ -28,12 +27,13 @@ program
 async function main() {
   const options = program.opts();
   options.expand = options.expand === true;
+  options.indent = options.indent === true;
 
   const bundlePaths = program.args;
   for (const bundlePath of bundlePaths) {
     process.stderr.write(C_PATH(`\nRunning bundle: ${bundlePath}\n`));
     try {
-      const rawReq = getRawRequest(bundlePath, options.expand, options.req, options.env);
+      const rawReq = new RawRequest(bundlePath, options);
       await callRequests(rawReq);
     } catch (e: any) {
       if (typeof e === "string") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ program
   .option("-r, --req <req-name>", "Run a request of a particular name")
   .option("-e, --env <env-name>", "Run the request in a particular environment")
   .option("--expand", "Show the body output in the terminal")
+  .option("--indent", "indent the failing tests for clarity in specs")
   .parse(process.argv);
 
 async function main() {

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -26,7 +26,7 @@ async function runRequestSpecs(
     request.httpRequest.headers = Object.assign(autoHeaders, request.httpRequest.headers);
   }
 
-  const responses = await allRequestsWithProgress(requests, rawRequest.bundle.bundlePath);
+  const responses = await allRequestsWithProgress(requests, rawRequest.bundle.bundlePath, rawRequest.indent);
   if (responses.length < 1) return;
 
   // if requestName is not set, then it is meant to be a run-all requests, else run-one

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -26,7 +26,11 @@ async function runRequestSpecs(
     request.httpRequest.headers = Object.assign(autoHeaders, request.httpRequest.headers);
   }
 
-  const responses = await allRequestsWithProgress(requests, rawRequest.bundle.bundlePath, rawRequest.indent);
+  const responses = await allRequestsWithProgress(
+    requests,
+    rawRequest.bundle.bundlePath,
+    rawRequest.indent,
+  );
   if (responses.length < 1) return;
 
   // if requestName is not set, then it is meant to be a run-all requests, else run-one

--- a/src/showRes.ts
+++ b/src/showRes.ts
@@ -1,7 +1,5 @@
 import { ResponseData } from "zzapi";
 
-import { getRawRequest } from "./utils/requestUtils";
-
 const KEYS_IN_BODY = ["body"];
 const KEYS_IN_HEADERS = ["rawHeaders"];
 

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -1,32 +1,22 @@
+import { OptionValues } from "commander";
 import { Bundle } from "./bundleUtils";
 
 export class RawRequest {
   public requestName: string | undefined = undefined;
   public envName: string | undefined = undefined;
   public expand: boolean = false;
+  public indent: boolean = false;
   public bundle: Bundle;
 
-  constructor(relPath: string, expand: boolean, requestName?: string, envName?: string) {
+  constructor(relPath: string, opts: OptionValues) {
     try {
       this.bundle = new Bundle(relPath);
-      this.requestName = requestName;
-      this.envName = envName;
-      this.expand = expand;
+      this.requestName = opts.req;
+      this.envName = opts.env;
+      this.expand = opts.expand;
+      this.indent = opts.indent;
     } catch (e) {
       throw e;
     }
-  }
-}
-
-export function getRawRequest(
-  relPath: string,
-  expand: boolean,
-  requestName?: string,
-  envName?: string,
-): RawRequest {
-  try {
-    return new RawRequest(relPath, expand, requestName, envName);
-  } catch (error) {
-    throw error;
   }
 }


### PR DESCRIPTION
- adds an option - `--indent` - which shows the output in an indented format if invoked
![Screenshot from 2024-06-04 10-50-03](https://github.com/agrostar/zzapi-cli/assets/125901917/3807277b-bbee-4eec-a638-0396e75df084)
- by default, the output is "flat"
![Screenshot from 2024-06-04 10-50-27](https://github.com/agrostar/zzapi-cli/assets/125901917/623184d7-2be3-4a11-aa29-5c51fe8b98d2)

