### PR TITLE
display SKIP in case of $skip clause present in spec of given test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "chalk": "4.1.2",
         "commander": "^11.1.0",
-        "zzapi": "^1.4.0"
+        "zzapi": "^1.5.0"
       },
       "bin": {
         "zzapi-cli": "dist/index.js"
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/zzapi": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/zzapi/-/zzapi-1.4.0.tgz",
-      "integrity": "sha512-yaXmCmUgR8f3dEOZPhgOZXdFs7ltNQ2rSkBkI60VgtPFQwDfJ3hkeG7ITjijGk5pPEFiQUx8w6C6zki/DQuQkA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/zzapi/-/zzapi-1.5.0.tgz",
+      "integrity": "sha512-yiulqIeGH3jSSwNIiXVVCXa1EMRhU827vlNbp6d3cPBsdHLOdAkKCnuNINwhaGz7luPSuJdpKA/jBO1VHdgjIA==",
       "dependencies": {
         "got": "11.8.6",
         "jsonpath": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "chalk": "4.1.2",
     "commander": "^11.1.0",
-    "zzapi": "^1.4.0"
+    "zzapi": "^1.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",

--- a/src/fileContents.ts
+++ b/src/fileContents.ts
@@ -1,8 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { getRawRequest } from "./utils/requestUtils";
-
 export function replaceFileContents<T>(body: T, bundlePath: string): T {
   if (typeof body !== "string") return body;
 

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -66,7 +66,7 @@ function getStatusString(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): string {
   const passRatio = all === 0 ? "" : `tests: ${passed}/${all} passed`;
   const summaryString = `${method} ${name} status: ${status} size: ${size} B time: ${execTime} ${passRatio}`;
@@ -83,7 +83,7 @@ function getFlatResult(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): [string, number, number] {
   const [passed, all, hasSkip] = getPassData(specRes);
   if (passed === all && !hasSkip)
@@ -116,7 +116,7 @@ function getIndentedResult(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): [string, number, number] {
   const [passed, all, hasSkip] = getPassData(specRes);
   if (passed === all && !hasSkip)
@@ -153,7 +153,7 @@ function getRequestResult(
   status: number | undefined,
   size: number,
   execTime: string | number,
-  indent: boolean
+  indent: boolean,
 ): [string, number, number] {
   return indent
     ? getIndentedResult(specRes, method, name, status, size, execTime)
@@ -165,7 +165,7 @@ export async function allRequestsWithProgress(
     [name: string]: RequestSpec;
   },
   bundlePath: string,
-  indent: boolean
+  indent: boolean,
 ): Promise<Array<{ name: string; response: ResponseData }>> {
   let currHttpRequest: GotRequest;
   let responses: Array<{ name: string; response: ResponseData }> = [];
@@ -248,7 +248,7 @@ export async function allRequestsWithProgress(
         C_TIME(`${new Date().toLocaleString()}`) +
         C_ERR(` [ERROR] `) +
         C_ERR_TEXT(
-          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`
+          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`,
         );
       process.stderr.write(`${message}\n`);
       process.exitCode = getStatusCode() + 1;

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -61,10 +61,6 @@ function getStatusString(
   size: number,
   execTime: string | number,
 ): string {
-  let message: string =
-    C_TIME(`${new Date().toLocaleString()}`) +
-    (all === passed ? C_SUC(` [INFO]  `) : C_ERR(` [ERROR] `));
-
   const passRatio = all === 0 ? "" : `tests: ${passed}/${all} passed`;
   const summaryString = `${method} ${name} status: ${status} size: ${size} B time: ${execTime} ${passRatio}`;
 

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -59,7 +59,7 @@ function getStatusString(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): string {
   let message: string =
     C_TIME(`${new Date().toLocaleString()}`) +
@@ -80,7 +80,7 @@ function getFlatResult(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): [string, number, number] {
   const [passed, all] = getPassData(specRes);
   if (passed === all)
@@ -113,7 +113,7 @@ function getIndentedResult(
   name: string,
   status: number | undefined,
   size: number,
-  execTime: string | number
+  execTime: string | number,
 ): [string, number, number] {
   const [passed, all] = getPassData(specRes);
   if (passed === all)
@@ -150,7 +150,7 @@ function getRequestResult(
   status: number | undefined,
   size: number,
   execTime: string | number,
-  indent: boolean
+  indent: boolean,
 ): [string, number, number] {
   return indent
     ? getIndentedResult(specRes, method, name, status, size, execTime)
@@ -162,7 +162,7 @@ export async function allRequestsWithProgress(
     [name: string]: RequestSpec;
   },
   bundlePath: string,
-  indent: boolean
+  indent: boolean,
 ): Promise<Array<{ name: string; response: ResponseData }>> {
   let currHttpRequest: GotRequest;
   let responses: Array<{ name: string; response: ResponseData }> = [];
@@ -245,7 +245,7 @@ export async function allRequestsWithProgress(
         C_TIME(`${new Date().toLocaleString()}`) +
         C_ERR(` [ERROR] `) +
         C_ERR_TEXT(
-          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`
+          `${method} ${name} status: ${status} size: ${size} B time: ${et} parse error(${parseError})`,
         );
       process.stderr.write(`${message}\n`);
       process.exitCode = getStatusCode() + 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,11 @@
 
 import { Command } from "commander";
 
-import { getRawRequest } from "./utils/requestUtils";
 import { CLI_NAME, CLI_VERSION } from "./utils/version";
-import { getStatusCode } from "./utils/errors";
 import { C_ERR_TEXT, C_PATH, C_WARN_TEXT } from "./utils/colours";
 
 import { callRequests } from "./runRequests";
+import { RawRequest } from "./utils/requestUtils";
 
 const program = new Command(CLI_NAME);
 program
@@ -28,12 +27,13 @@ program
 async function main() {
   const options = program.opts();
   options.expand = options.expand === true;
+  options.indent = options.indent === true;
 
   const bundlePaths = program.args;
   for (const bundlePath of bundlePaths) {
     process.stderr.write(C_PATH(`\nRunning bundle: ${bundlePath}\n`));
     try {
-      const rawReq = getRawRequest(bundlePath, options.expand, options.req, options.env);
+      const rawReq = new RawRequest(bundlePath, options);
       await callRequests(rawReq);
     } catch (e: any) {
       if (typeof e === "string") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ program
   .option("-r, --req <req-name>", "Run a request of a particular name")
   .option("-e, --env <env-name>", "Run the request in a particular environment")
   .option("--expand", "Show the body output in the terminal")
+  .option("--indent", "indent the failing tests for clarity in specs")
   .parse(process.argv);
 
 async function main() {

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -26,7 +26,7 @@ async function runRequestSpecs(
     request.httpRequest.headers = Object.assign(autoHeaders, request.httpRequest.headers);
   }
 
-  const responses = await allRequestsWithProgress(requests, rawRequest.bundle.bundlePath);
+  const responses = await allRequestsWithProgress(requests, rawRequest.bundle.bundlePath, rawRequest.indent);
   if (responses.length < 1) return;
 
   // if requestName is not set, then it is meant to be a run-all requests, else run-one

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -26,7 +26,11 @@ async function runRequestSpecs(
     request.httpRequest.headers = Object.assign(autoHeaders, request.httpRequest.headers);
   }
 
-  const responses = await allRequestsWithProgress(requests, rawRequest.bundle.bundlePath, rawRequest.indent);
+  const responses = await allRequestsWithProgress(
+    requests,
+    rawRequest.bundle.bundlePath,
+    rawRequest.indent,
+  );
   if (responses.length < 1) return;
 
   // if requestName is not set, then it is meant to be a run-all requests, else run-one

--- a/src/showRes.ts
+++ b/src/showRes.ts
@@ -1,7 +1,5 @@
 import { ResponseData } from "zzapi";
 
-import { getRawRequest } from "./utils/requestUtils";
-
 const KEYS_IN_BODY = ["body"];
 const KEYS_IN_HEADERS = ["rawHeaders"];
 

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -19,3 +19,7 @@ export const C_SUC_TEXT = chalkStderr.green;
 // warning
 export const C_WARN = chalkStderr.yellow.bold;
 export const C_WARN_TEXT = chalkStderr.yellow;
+
+// skip
+export const C_SKIP = chalkStderr.gray;
+export const C_SKIP_TEXT = chalkStderr.gray.bold;

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -21,5 +21,5 @@ export const C_WARN = chalkStderr.yellow.bold;
 export const C_WARN_TEXT = chalkStderr.yellow;
 
 // skip
-export const C_SKIP = chalkStderr.gray;
-export const C_SKIP_TEXT = chalkStderr.gray.bold;
+export const C_SKIP = chalkStderr.gray.bold;
+export const C_SKIP_TEXT = chalkStderr.gray;

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -1,32 +1,22 @@
+import { OptionValues } from "commander";
 import { Bundle } from "./bundleUtils";
 
 export class RawRequest {
   public requestName: string | undefined = undefined;
   public envName: string | undefined = undefined;
   public expand: boolean = false;
+  public indent: boolean = false;
   public bundle: Bundle;
 
-  constructor(relPath: string, expand: boolean, requestName?: string, envName?: string) {
+  constructor(relPath: string, opts: OptionValues) {
     try {
       this.bundle = new Bundle(relPath);
-      this.requestName = requestName;
-      this.envName = envName;
-      this.expand = expand;
+      this.requestName = opts.req;
+      this.envName = opts.env;
+      this.expand = opts.expand;
+      this.indent = opts.indent;
     } catch (e) {
       throw e;
     }
-  }
-}
-
-export function getRawRequest(
-  relPath: string,
-  expand: boolean,
-  requestName?: string,
-  envName?: string,
-): RawRequest {
-  try {
-    return new RawRequest(relPath, expand, requestName, envName);
-  } catch (error) {
-    throw error;
   }
 }


### PR DESCRIPTION
NOTE: This depends on [the PR in zzapi](https://github.com/agrostar/zzapi/pull/8) that introduces the $skip clause.

- display SKIP for tests with $skip attribute present in their spec.
- expand all test results in case of any present $skip clause in spec itself or any sub-spec.