### PR TITLE
Fix variable file sorting

### DIFF
--- a/src/variables.ts
+++ b/src/variables.ts
@@ -8,7 +8,7 @@ const VARFILE_EXTENSION = ".zzv";
 
 function getVarFilePaths(dirPath: string): string[] {
   const dirContents = fs.readdirSync(dirPath, { recursive: false, encoding: "utf-8" });
-  const varFiles = dirContents.filter((file) => path.extname(file) == VARFILE_EXTENSION);
+  const varFiles = dirContents.filter((file) => path.extname(file) === VARFILE_EXTENSION).sort();
   const varFilePaths = varFiles.map((file) => path.join(dirPath, file));
 
   return varFilePaths;


### PR DESCRIPTION
This one is subtle.

I have two different WSL2 workstations that I switch between. I am using `bun` on both, not `node`. One machine is able to run all tests, the other fails - the configuration is identical.

After adding some debug console output to `zzapi-cli`, I have been able to isolate the root cause to the order of variable files returned from the JS VM. `node` appears to return the same alphabetic order on both systems. `bun` is returning alphabetic on one system and reverse order on the other. I suspect the filesystems may be slightly different between the two workstations since the VMs are different ages.

Either way, it might be better to be more declarative on the variable loading order rather than relying on the presumed order from the JS VM.