### PR TITLE
Track bundle results and summarize with table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "4.1.2",
         "commander": "^11.1.0",
+        "table": "^6.8.2",
         "zzapi": "^1.5.1"
       },
       "bin": {
@@ -83,6 +84,29 @@
         "@types/node": "*"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -95,6 +119,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -210,6 +242,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -279,6 +316,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -347,10 +389,23 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/jsonpath": {
       "version": "1.1.1",
@@ -381,6 +436,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -458,6 +518,14 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -467,6 +535,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-alpn": {
@@ -483,6 +559,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/source-map": {
@@ -502,6 +594,30 @@
         "escodegen": "^1.8.1"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -511,6 +627,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
+      "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/type-check": {
@@ -546,6 +677,14 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "chalk": "4.1.2",
     "commander": "^11.1.0",
+    "table": "^6.8.2",
     "zzapi": "^1.5.1"
   },
   "devDependencies": {

--- a/src/bundleResult.ts
+++ b/src/bundleResult.ts
@@ -1,0 +1,108 @@
+import { getBorderCharacters, table } from "table";
+import { C_ERR, C_ERR_TEXT, C_SPEC, C_SUC, C_SUC_TEXT, C_TEXT, C_TEXT_BOLD } from "./utils/colours";
+import { SpecResponse } from "./specResponse";
+
+export class BundleResult {
+  public bundlePath: string;
+  public passedSpecs = 0;
+  public allSpecs = 0;
+  public passedTests = 0;
+  public allTests = 0;
+  public duration = 0;
+
+  constructor(bundlePath: string) {
+    this.bundlePath = bundlePath;
+  }
+
+  addResult(bundle: BundleResult) {
+    this.passedSpecs += bundle.passedSpecs;
+    this.allSpecs += bundle.allSpecs;
+    this.passedTests += bundle.passedTests;
+    this.allTests += bundle.allTests;
+    this.duration += bundle.duration;
+  }
+
+  addResponses(responses: SpecResponse[]) {
+    this.allSpecs += responses.length;
+    for (const response of responses) {
+      this.passedTests += response.passedTests;
+      this.allTests += response.allTests;
+      this.passedSpecs += response.passedTests === response.allTests ? 1 : 0;
+    }
+  }
+}
+
+export function displaySummary(bundleResults: BundleResult[]) {
+  if (bundleResults.length) {
+    const suite = new BundleResult("All Bundles");
+
+    const data = [];
+    data.push(["Bundle", "", "Specs", "Tests", "Duration"]);
+
+    for (const bundle of bundleResults) {
+      suite.addResult(bundle);
+      data.push([
+        renderBundle(bundle.bundlePath),
+        renderCheck(bundle.passedSpecs, bundle.allSpecs),
+        renderStatus(bundle.passedSpecs, bundle.allSpecs),
+        renderStatus(bundle.passedTests, bundle.allTests),
+        renderDuration(bundle.duration),
+      ]);
+    }
+    if (bundleResults.length > 1) {
+      data.push([
+        renderBundle(suite.bundlePath),
+        renderCheck(suite.passedSpecs, suite.allSpecs),
+        renderStatus(suite.passedSpecs, suite.allSpecs),
+        renderStatus(suite.passedTests, suite.allTests),
+        renderDuration(suite.duration),
+      ]);
+    }
+
+    const config = {
+      border: getBorderCharacters("norc"),
+      drawHorizontalLine: (lineIndex: number, rowCount: number) => {
+        return lineIndex <= 1 || lineIndex >= rowCount - 1;
+      },
+    };
+
+    process.stderr.write(`\n${table(data, config)}`);
+  }
+}
+
+function renderBundle(bundlePath: string) {
+  return C_TEXT_BOLD(bundlePath);
+}
+
+function renderCheck(passed: number, total: number) {
+  return total === 0 ? C_TEXT("✓") : passed === total ? C_SUC("✓") : C_ERR("✗");
+}
+
+function renderStatus(passed: number, total: number) {
+  if (total === 0) {
+    return "---";
+  }
+
+  const score = Math.round((passed / total) * 100).toFixed(1);
+  return passed === total
+    ? C_SUC_TEXT(`${score}%`) +
+        C_TEXT(" (") +
+        C_SUC_TEXT(passed) +
+        C_TEXT("/") +
+        C_SPEC(total) +
+        C_TEXT(")")
+    : C_SUC_TEXT(`${score}%`) +
+        C_TEXT(" (") +
+        C_ERR_TEXT(total - passed) +
+        C_TEXT("/") +
+        C_SUC_TEXT(passed) +
+        C_TEXT("/") +
+        C_SPEC(total) +
+        C_TEXT(")");
+}
+
+function renderDuration(duration: number) {
+  return duration >= 1000
+    ? C_TEXT(`${(duration / 1000).toFixed(3)} secs`)
+    : C_TEXT(`${Math.round(duration).toFixed(0)} msecs`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { RawRequest } from "./utils/requestUtils";
 import { getStatusCode } from "./utils/errors";
 
 import { callRequests } from "./runRequests";
+import { displaySummary } from "./bundleResult";
 
 const program = new Command(CLI_NAME);
 program
@@ -31,11 +32,14 @@ async function main() {
   options.indent = options.indent === true;
 
   const bundlePaths = program.args;
+  const bundleResults = [];
   for (const bundlePath of bundlePaths) {
     process.stderr.write(C_PATH(`\nRunning bundle: ${bundlePath}\n`));
     try {
       const rawReq = new RawRequest(bundlePath, options);
-      await callRequests(rawReq);
+      const bundleResult = await callRequests(rawReq);
+      bundleResult.bundlePath = bundlePath;
+      bundleResults.push(bundleResult);
     } catch (e: any) {
       if (typeof e === "string") {
         process.stderr.write(C_ERR_TEXT(`${e}\n`));
@@ -46,6 +50,8 @@ async function main() {
       continue;
     }
   }
+
+  displaySummary(bundleResults);
 }
 
 main();

--- a/src/specResponse.ts
+++ b/src/specResponse.ts
@@ -1,0 +1,8 @@
+import { ResponseData } from "zzapi";
+
+export type SpecResponse = {
+  name: string;
+  response: ResponseData;
+  passedTests: number;
+  allTests: number;
+};

--- a/src/utils/colours.ts
+++ b/src/utils/colours.ts
@@ -5,6 +5,7 @@ export const C_PATH = chalkStderr.cyan; // path
 export const C_LOADING = chalkStderr.blue.italic; // loading
 export const C_TIME = chalkStderr.gray; // time
 
+export const C_BUNDLE = chalkStderr.white;
 export const C_SPEC = chalkStderr.white; // spec
 
 export const C_STATUS = chalkStderr.cyanBright;


### PR DESCRIPTION
## Description

In my quest to enhance the CLI experience, summarizing execution results has been on my list.

## Changes

- Introduced [`table`](https://www.npmjs.com/package/table) as a dependency for creating simple tables/grids.
- Instrumented code to track `BundleResult` instances
- Display a summary table at the conclusion of CLI execution
- De-emphasize the bundle name in specs so that the spec name stands-out

| One Bundle | Multiple Bundles |
|-----------|---------|
| <img width="703" alt="image" src="https://github.com/agrostar/zzapi-cli/assets/868217/25ffc8e2-01c1-48c7-9a61-362356166cb4"> | <img width="680" alt="image" src="https://github.com/agrostar/zzapi-cli/assets/868217/83423f69-aeca-4cc7-adc8-9d87cd11c7cb"> |
