### PR TITLE
ensure different VarStores for each RawRequest

### DIFF
--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -1,3 +1,5 @@
+import path from "path";
+
 import { ResponseData, RequestSpec, GotRequest, TestResult, SpecResult } from "zzapi";
 import { constructGotRequest, executeGotRequest } from "zzapi";
 import { runAllTests } from "zzapi";
@@ -22,9 +24,9 @@ import {
   C_SPEC,
 } from "./utils/colours";
 import { getStatusCode } from "./utils/errors";
-import { replaceFileContents } from "./fileContents";
-import path from "path";
 import { RawRequest } from "./utils/requestUtils";
+
+import { replaceFileContents } from "./fileContents";
 
 const requestDetailInset = " ".repeat(new Date().toLocaleString().length + 3);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,9 @@ import { Command } from "commander";
 
 import { CLI_NAME, CLI_VERSION } from "./utils/version";
 import { C_ERR_TEXT, C_PATH, C_WARN_TEXT } from "./utils/colours";
+import { RawRequest } from "./utils/requestUtils";
 
 import { callRequests } from "./runRequests";
-import { RawRequest } from "./utils/requestUtils";
 
 const program = new Command(CLI_NAME);
 program

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -10,7 +10,7 @@ import { CLI_VERSION } from "./utils/version";
 
 import { showContentForIndReq, showContentForAllReq } from "./showRes";
 import { allRequestsWithProgress } from "./getResponse";
-import { getVarFileContents, getVarStore } from "./variables";
+import { getVarFileContents } from "./variables";
 
 async function runRequestSpecs(
   requests: { [name: string]: RequestSpec },
@@ -26,11 +26,7 @@ async function runRequestSpecs(
     request.httpRequest.headers = Object.assign(autoHeaders, request.httpRequest.headers);
   }
 
-  const responses = await allRequestsWithProgress(
-    requests,
-    rawRequest.bundle.bundlePath,
-    rawRequest.indent,
-  );
+  const responses = await allRequestsWithProgress(requests, rawRequest);
   if (responses.length < 1) return;
 
   // if requestName is not set, then it is meant to be a run-all requests, else run-one
@@ -62,7 +58,7 @@ export async function callRequests(request: RawRequest): Promise<void> {
     );
     if (env && Object.keys(loadedVariables).length < 1)
       console.error(C_WARN(`warning: no variables added from env "${env}". Does it exist?`));
-    getVarStore().setLoadedVariables(loadedVariables);
+    request.variables.setLoadedVariables(loadedVariables);
   } catch (err: any) {
     throw err;
   }

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -1,5 +1,6 @@
 import { OptionValues } from "commander";
 import { Bundle } from "./bundleUtils";
+import { VarStore } from "zzapi";
 
 export class RawRequest {
   public requestName: string | undefined = undefined;
@@ -7,6 +8,7 @@ export class RawRequest {
   public expand: boolean = false;
   public indent: boolean = false;
   public bundle: Bundle;
+  public variables: VarStore;
 
   constructor(relPath: string, opts: OptionValues) {
     try {
@@ -15,6 +17,7 @@ export class RawRequest {
       this.envName = opts.env;
       this.expand = opts.expand;
       this.indent = opts.indent;
+      this.variables = new VarStore();
     } catch (e) {
       throw e;
     }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -30,8 +30,3 @@ export function getVarFileContents(dirPath: string): string[] {
 export function getEnvNames(dirPath: string, bundleContent: string): string[] {
   return getEnvironments(bundleContent, getVarFileContents(dirPath));
 }
-
-let variables = new VarStore();
-export function getVarStore(): VarStore {
-  return variables;
-}

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -2,7 +2,6 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { getEnvironments } from "zzapi";
-import { VarStore } from "zzapi";
 
 const VARFILE_EXTENSION = ".zzv";
 


### PR DESCRIPTION
- previously, was using a single VarStore which was not migrated to a per-request store during the migration to accomodate multiple bundles in a single command. 