### PR TITLE
Fix Github workflows for PR testing

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,5 +1,5 @@
 name: formatting 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   format:

--- a/.github/workflows/test_bundle.yml
+++ b/.github/workflows/test_bundle.yml
@@ -1,5 +1,5 @@
 name: module testing 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   format:


### PR DESCRIPTION
My PRs never run checks, but @Varun0157's do. I think this is because their PRs are branches in this repository and mine are from a fork and therefore do not appear as a `push`.

I've updated the workflows to also trigger on `pull_request`.

<img width="446" alt="image" src="https://github.com/agrostar/zzapi-cli/assets/868217/7189f190-c487-49b3-b251-870a2237b0bf">