### PR TITLE
introduce separate varstores on a per-request basis

### DIFF
--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -40,7 +40,7 @@ function formatRoute(
   et: string | number,
   size: number,
   passedCount: number,
-  allCount: number
+  allCount: number,
 ) {
   let line = C_TIME(`${new Date().toLocaleString()}`);
   if (allCount === passedCount) {
@@ -85,7 +85,7 @@ function formatRouteParseError(
   status: number | undefined,
   size: number,
   et: string | number,
-  parseError: string
+  parseError: string,
 ) {
   const line =
     C_TIME(`${new Date().toLocaleString()}`) +
@@ -115,7 +115,7 @@ function formatTestResults(
   results: TestResult[],
   lastResult: TestResult | undefined,
   skip: boolean,
-  indented: boolean
+  indented: boolean,
 ): string[] {
   const resultLines: string[] = [];
   for (const [i, r] of results.entries()) {
@@ -124,8 +124,8 @@ function formatTestResults(
         ? "└"
         : "├" // flat view
       : i === results.length - 1
-      ? "└"
-      : "├"; // indented/nested view
+        ? "└"
+        : "├"; // indented/nested view
 
     // Indented presentation displays spec on a dedicated line, otherwise specs are displayed inline.
     const specToken = spec && !indented ? `${spec} ` : "";
@@ -183,7 +183,7 @@ function getFormattedResult(
   status: number | undefined,
   size: number,
   execTime: string | number,
-  indented: boolean
+  indented: boolean,
 ): [string, number, number] {
   function getResultData(res: SpecResult): [number, number] {
     const rootResults = res.results;
@@ -206,7 +206,7 @@ function getFormattedResult(
   function getIndentedResult(
     res: SpecResult,
     indent: number,
-    lastResult: TestResult | undefined
+    lastResult: TestResult | undefined,
   ): string {
     const offset = "  ";
     const inset = requestDetailInset + (indented ? offset.repeat(Math.max(1, indent - 1)) : "");
@@ -217,7 +217,7 @@ function getFormattedResult(
       res.results,
       lastResult,
       res.skipped ?? false,
-      indented
+      indented,
     ).join("\n");
 
     const subRes: string[] = [];
@@ -280,7 +280,7 @@ export async function allRequestsWithProgress(
   allRequests: {
     [name: string]: RequestSpec;
   },
-  rawReq: RawRequest
+  rawReq: RawRequest,
 ): Promise<Array<SpecResponse>> {
   let currHttpRequest: GotRequest;
   const responses: Array<SpecResponse> = [];
@@ -358,7 +358,7 @@ export async function allRequestsWithProgress(
       status,
       size,
       et,
-      rawReq.indent
+      rawReq.indent,
     );
     if (passed !== all) process.exitCode = getStatusCode() + 1;
 

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -15,7 +15,7 @@ import { BundleResult } from "./bundleResult";
 
 async function runRequestSpecs(
   requests: { [name: string]: RequestSpec },
-  rawRequest: RawRequest
+  rawRequest: RawRequest,
 ): Promise<BundleResult> {
   for (const name in requests) {
     const request = requests[name];
@@ -44,7 +44,7 @@ async function runRequestSpecs(
       req.options.keepRawJSON,
       req.options.showHeaders,
       rawRequest.envName,
-      rawRequest.expand
+      rawRequest.expand,
     );
   }
 
@@ -60,7 +60,7 @@ export async function callRequests(request: RawRequest): Promise<BundleResult> {
     const loadedVariables: Variables = loadVariables(
       env,
       request.bundle.bundleContents,
-      getVarFileContents(path.dirname(request.bundle.bundlePath))
+      getVarFileContents(path.dirname(request.bundle.bundlePath)),
     );
     if (env && Object.keys(loadedVariables).length < 1)
       console.error(C_WARN(`warning: no variables added from env "${env}". Does it exist?`));

--- a/src/runRequests.ts
+++ b/src/runRequests.ts
@@ -10,12 +10,12 @@ import { CLI_VERSION } from "./utils/version";
 
 import { showContentForIndReq, showContentForAllReq } from "./showRes";
 import { allRequestsWithProgress } from "./getResponse";
-import { getVarFileContents, getVarStore } from "./variables";
+import { getVarFileContents } from "./variables";
 import { BundleResult } from "./bundleResult";
 
 async function runRequestSpecs(
   requests: { [name: string]: RequestSpec },
-  rawRequest: RawRequest,
+  rawRequest: RawRequest
 ): Promise<BundleResult> {
   for (const name in requests) {
     const request = requests[name];
@@ -27,11 +27,7 @@ async function runRequestSpecs(
     request.httpRequest.headers = Object.assign(autoHeaders, request.httpRequest.headers);
   }
 
-  const responses = await allRequestsWithProgress(
-    requests,
-    rawRequest.bundle.bundlePath,
-    rawRequest.indent,
-  );
+  const responses = await allRequestsWithProgress(requests, rawRequest);
 
   if (responses.length < 1) return new BundleResult(rawRequest.bundle.bundlePath);
 
@@ -48,7 +44,7 @@ async function runRequestSpecs(
       req.options.keepRawJSON,
       req.options.showHeaders,
       rawRequest.envName,
-      rawRequest.expand,
+      rawRequest.expand
     );
   }
 
@@ -64,11 +60,11 @@ export async function callRequests(request: RawRequest): Promise<BundleResult> {
     const loadedVariables: Variables = loadVariables(
       env,
       request.bundle.bundleContents,
-      getVarFileContents(path.dirname(request.bundle.bundlePath)),
+      getVarFileContents(path.dirname(request.bundle.bundlePath))
     );
     if (env && Object.keys(loadedVariables).length < 1)
       console.error(C_WARN(`warning: no variables added from env "${env}". Does it exist?`));
-    getVarStore().setLoadedVariables(loadedVariables);
+    request.variables.setLoadedVariables(loadedVariables);
   } catch (err: any) {
     throw err;
   }
@@ -84,7 +80,7 @@ export async function callRequests(request: RawRequest): Promise<BundleResult> {
     throw err;
   }
 
-  // finally, run the request specs 
+  // finally, run the request specs
   const t0 = performance.now();
   const bundleResult = await runRequestSpecs(allRequests, request);
   const t1 = performance.now();

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -1,5 +1,6 @@
 import { OptionValues } from "commander";
 import { Bundle } from "./bundleUtils";
+import { VarStore } from "zzapi";
 
 export class RawRequest {
   public requestName: string | undefined = undefined;
@@ -7,6 +8,7 @@ export class RawRequest {
   public expand: boolean = false;
   public indent: boolean = false;
   public bundle: Bundle;
+  public variables: VarStore;
 
   constructor(relPath: string, opts: OptionValues) {
     try {
@@ -15,6 +17,7 @@ export class RawRequest {
       this.envName = opts.env;
       this.expand = opts.expand;
       this.indent = opts.indent;
+      this.variables = new VarStore();
     } catch (e) {
       throw e;
     }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -30,8 +30,3 @@ export function getVarFileContents(dirPath: string): string[] {
 export function getEnvNames(dirPath: string, bundleContent: string): string[] {
   return getEnvironments(bundleContent, getVarFileContents(dirPath));
 }
-
-let variables = new VarStore();
-export function getVarStore(): VarStore {
-  return variables;
-}


### PR DESCRIPTION
Introduces varStores on a per-request basis to ensure distinct working. 
This should have been introduced along with the allowance of multiple bundle arguments in the command line. 