### PR TITLE
Optional Markdown summary generation

### DIFF
--- a/src/bundleResult.ts
+++ b/src/bundleResult.ts
@@ -106,3 +106,46 @@ function renderDuration(duration: number) {
     ? C_TEXT(`${(duration / 1000).toFixed(3)} secs`)
     : C_TEXT(`${Math.round(duration).toFixed(0)} msecs`);
 }
+
+export function markdownSummary(bundleResults: BundleResult[]) {
+  let report = "";
+  report += "| Bundle |   | Specs | Tests | Duration |\n";
+  report += "|--------|---|-------|-------|----------|\n";
+
+  const suite = new BundleResult("All Bundles");
+  for (const bundleResult of bundleResults) {
+    suite.addResult(bundleResult);
+    report += markdownRow(bundleResult.bundlePath, bundleResult);
+  }
+
+  report += markdownRow(`**${suite.bundlePath}**`, suite);
+  report += "\n";
+
+  function markdownRow(bundleName: string, bundleResult: BundleResult): string {
+    const status =
+      bundleResult.allTests === 0 || bundleResult.passedTests === bundleResult.allTests ? "✅" : "❌";
+
+    const specs = markdownResult(bundleResult.passedSpecs, bundleResult.allSpecs);
+    const tests = markdownResult(bundleResult.passedTests, bundleResult.allTests);
+
+    const duration =
+      bundleResult.duration >= 1000
+        ? `${(bundleResult.duration / 1000).toFixed(3)} secs`
+        : `${Math.round(bundleResult.duration).toFixed(0)} msecs`;
+
+    return `| ${bundleName} | ${status} | ${specs} | ${tests} | ${duration} |\n`;
+  }
+
+  function markdownResult(passed: number, total: number) {
+    if (total === 0) {
+      return "`---`";
+    }
+
+    const score = Math.round((passed / total) * 100).toFixed(1);
+    return passed === total
+      ? `${score}% (\`${passed}\` / \`${total}\`)`
+      : `${score}% (❌ \`${total - passed}\` / ✅ \`${passed}\` / \`${total}\`)`;
+  }
+
+  return report;
+}


### PR DESCRIPTION
This PR adds an optional CLI parameter (`--report`) which will create a Markdown file of the bundle results summary table in the current directory. You can optionally specify an alternate directory using `--report-dir`.

The purpose of generating a Markdown version of the summary is to provide content to append to a Github Job Summary.

![image](https://github.com/agrostar/zzapi-cli/assets/868217/8e5978d6-0f0f-4d26-9f12-d930acfaa351)

The example workflow I have leverages an action ([x-color/github-actions-job-summary](https://github.com/marketplace/actions/github-actions-job-summary)) which is a little quirky and could use 1 bug fix and some updating, but it proves out the concept.

Aside from generating the Markdown file, the key to the flow is to prevent the zzapi step from exiting so that the next step can upload the Markdown report with a conditional exit afterwards.

```yaml
  zzapi-test:
    name: zzAPI tests
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: oven-sh/setup-bun@v1
      - run: bun install --frozen-lockfile
      - name: zzapi
        id: zzapi
        run: |
          bun run dev &
          bun run zzapi
        continue-on-error: true
      - uses: x-color/github-actions-job-summary@v0.1.0
        with:
          file: zzapi-results.md
          vars: | # this action REQUIRES declaring a variable. Boo.
            time: ${{ steps.time.outputs.time }}
      - name: when zzapi fails
        if: ${{ steps.zzapi.outcome == 'failure' }}
        run: exit 1
```